### PR TITLE
fix: KeyAttestation#key failing when using libopenssl v1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@ dist: bionic
 language: ruby
 cache: bundler
 
-rvm:
-  - ruby-head
-  - 2.7.1
-  - 2.6.6
-  - 2.5.8
-  - 2.4.10
+env:
+  - RB=2.7.1 LIBSSL=1.0
+  - RB=2.7.1 LIBSSL=1.1
+  - RB=2.6.6 LIBSSL=1.0
+  - RB=2.6.6 LIBSSL=1.1
+  - RB=2.5.8 LIBSSL=1.0
+  - RB=2.5.8 LIBSSL=1.1
+  - RB=2.4.10 LIBSSL=1.0
+  - RB=2.4.10 LIBSSL=1.1
+  - RB=ruby-head LIBSSL=1.0
+  - RB=ruby-head LIBSSL=1.1
 
 gemfile:
   - gemfiles/openssl_head.gemfile
@@ -19,9 +24,12 @@ gemfile:
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: ruby-head
+    - env: RB=ruby-head LIBSSL=1.0
+    - env: RB=ruby-head LIBSSL=1.1
     - gemfile: gemfiles/openssl_head.gemfile
 
 before_install:
+  - ./install-openssl.sh
+  - ./install-ruby.sh
   - gem install bundler -v "~> 2.0"
   - rm Gemfile.lock

--- a/install-openssl.sh
+++ b/install-openssl.sh
@@ -1,0 +1,3 @@
+if [[ "${LIBSSL}" == "1.0" ]]; then
+  sudo apt purge libssl-dev && sudo apt-get -yq --no-install-suggests --no-install-recommends install libssl1.0-dev
+fi

--- a/install-ruby.sh
+++ b/install-ruby.sh
@@ -1,0 +1,10 @@
+source ~/.rvm/scripts/rvm
+
+if [[ "${LIBSSL}" == "1.0" ]]; then
+  rvm install $RB --autolibs=read-only -C --with-openssl-dir=usr/include/openssl
+elif [[ "${LIBSSL}" == "1.1" ]]; then
+  rvm install $RB --binary --fuzzy
+fi
+
+rvm use $RB
+ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'

--- a/lib/tpm/t_public.rb
+++ b/lib/tpm/t_public.rb
@@ -11,6 +11,7 @@ module TPM
   class TPublic < BinData::Record
     BYTE_LENGTH = 8
     CURVE_TPM_TO_OPENSSL = { TPM::ECC_NIST_P256 => "prime256v1" }.freeze
+    RSA_KEY_DEFAULT_PUBLIC_EXPONENT = 2**16 + 1
 
     class << self
       alias_method :deserialize, :read
@@ -74,7 +75,7 @@ module TPM
 
         if parameters.key_bits / BYTE_LENGTH == n.size
           key = OpenSSL::PKey::RSA.new(parameters.key_bits.value)
-          key.set_key(bn(n), nil, nil)
+          key.set_key(bn(n), bn(RSA_KEY_DEFAULT_PUBLIC_EXPONENT), nil)
 
           key.public_key
         end

--- a/spec/tpm/key_attestation_spec.rb
+++ b/spec/tpm/key_attestation_spec.rb
@@ -7,69 +7,71 @@ RSpec.describe TPM::KeyAttestation do
     expect(TPM::KeyAttestation::VERSION).not_to be nil
   end
 
+  let(:key_attestation) do
+    TPM::KeyAttestation.new(
+      certify_info,
+      signature,
+      certified_key,
+      certificates,
+      qualifying_data,
+      signature_algorithm: signature_algorithm,
+      hash_algorithm: hash_algorithm,
+      root_certificates: root_certificates
+    )
+  end
+
+  let(:certificates) { [certificate.to_der] }
+
+  let(:certificate) do
+    create_certificate(attestation_key, root_certificate, root_key)
+  end
+
+  let(:root_certificates) { [root_certificate] }
+
+  let(:root_certificate) { create_root_certificate(root_key) }
+  let(:root_key) { create_rsa_key }
+
+  let(:certify_info) do
+    s_attest = TPM::SAttest.new
+    s_attest.magic = certify_info_magic
+    s_attest.attested_type = TPM::ST_ATTEST_CERTIFY
+    s_attest.extra_data.buffer = certify_info_extra_data
+    s_attest.attested.name.name.hash_alg = name_alg
+    s_attest.attested.name.name.digest = certify_info_attested_name_digest
+
+    s_attest.to_binary_s
+  end
+
+  let(:signature_algorithm) { TPM::ALG_RSASSA }
+  let(:hash_algorithm) { TPM::ALG_SHA256 }
+  let(:signature) { attestation_key.sign(hash_function, to_be_signed) }
+
+  let(:certify_info_magic) { TPM::GENERATED_VALUE }
+  let(:certify_info_extra_data) { qualifying_data }
+  let(:certify_info_attested_name_digest) { OpenSSL::Digest::SHA1.digest(certified_key) }
+  let(:name_alg) { TPM::ALG_SHA1 }
+  let(:to_be_signed) { certify_info }
+
+  let(:attested_key) { create_rsa_key }
+  let(:attested_key_length) { attested_key.n.num_bits }
+  let(:certified_key) do
+    t_public = TPM::TPublic.new
+    t_public.alg_type = TPM::ALG_RSA
+    t_public.name_alg = name_alg
+    t_public.parameters.symmetric = TPM::ALG_NULL
+    t_public.parameters.scheme = TPM::ALG_RSASSA
+    t_public.parameters.key_bits = attested_key_length
+    t_public.parameters.exponent = 0x00
+    t_public.unique.buffer = attested_key.params["n"].to_s(2)
+
+    t_public.to_binary_s
+  end
+
+  let(:hash_function) { "SHA256" }
+  let(:qualifying_data) { OpenSSL::Digest::SHA256.digest("qualifying-data") }
+  let(:attestation_key) { create_rsa_key }
+
   describe "#valid?" do
-    let(:key_attestation) do
-      TPM::KeyAttestation.new(
-        certify_info,
-        signature,
-        attested_object,
-        certificates,
-        qualifying_data,
-        signature_algorithm: signature_algorithm,
-        hash_algorithm: hash_algorithm,
-        root_certificates: root_certificates
-      )
-    end
-
-    let(:certificates) { [certificate.to_der] }
-
-    let(:certificate) do
-      create_certificate(attestation_key, root_certificate, root_key)
-    end
-
-    let(:root_certificates) { [root_certificate] }
-
-    let(:root_certificate) { create_root_certificate(root_key) }
-    let(:root_key) { create_rsa_key }
-
-    let(:certify_info) do
-      s_attest = TPM::SAttest.new
-      s_attest.magic = certify_info_magic
-      s_attest.attested_type = TPM::ST_ATTEST_CERTIFY
-      s_attest.extra_data.buffer = certify_info_extra_data
-      s_attest.attested.name.name.hash_alg = name_alg
-      s_attest.attested.name.name.digest = certify_info_attested_name_digest
-
-      s_attest.to_binary_s
-    end
-
-    let(:signature_algorithm) { TPM::ALG_RSASSA }
-    let(:hash_algorithm) { TPM::ALG_SHA256 }
-    let(:signature) { attestation_key.sign(hash_function, to_be_signed) }
-
-    let(:certify_info_magic) { TPM::GENERATED_VALUE }
-    let(:certify_info_extra_data) { qualifying_data }
-    let(:certify_info_attested_name_digest) { OpenSSL::Digest::SHA1.digest(attested_object) }
-    let(:name_alg) { TPM::ALG_SHA1 }
-    let(:to_be_signed) { certify_info }
-
-    let(:attested_object) do
-      t_public = TPM::TPublic.new
-      t_public.alg_type = TPM::ALG_RSA
-      t_public.name_alg = name_alg
-      t_public.parameters.symmetric = TPM::ALG_NULL
-      t_public.parameters.scheme = TPM::ALG_RSASSA
-      t_public.parameters.key_bits = 1024
-      t_public.parameters.exponent = 0x00
-      t_public.unique.buffer = OpenSSL::PKey::RSA.new(1024).params["n"].to_s(2)
-
-      t_public.to_binary_s
-    end
-
-    let(:hash_function) { "SHA256" }
-    let(:qualifying_data) { OpenSSL::Digest::SHA256.digest("qualifying-data") }
-    let(:attestation_key) { create_rsa_key }
-
     context "when everything's in place" do
       it "returns true" do
         expect(key_attestation).to be_valid
@@ -147,7 +149,7 @@ RSpec.describe TPM::KeyAttestation do
       context "because attested name is not a valid name for attested object" do
         context "because it was hashed on different data" do
           let(:certify_info_attested_name_digest) do
-            OpenSSL::Digest::SHA1.digest(attested_object + "X")
+            OpenSSL::Digest::SHA1.digest(certified_key + "X")
           end
 
           it "returns false" do
@@ -157,13 +159,64 @@ RSpec.describe TPM::KeyAttestation do
 
         context "because it was hashed with a different algorithm" do
           let(:certify_info_attested_name_digest) do
-            OpenSSL::Digest::SHA256.digest(attested_object)
+            OpenSSL::Digest::SHA256.digest(certified_key)
           end
 
           it "returns false" do
             expect(key_attestation).not_to be_valid
           end
         end
+      end
+    end
+  end
+
+  describe "#key" do
+    context "when everything's in place" do
+      it "returns a public RSA key with correct size" do
+        expect(key_attestation.key.n.num_bits).to be 1024
+      end
+
+      it "returns a public RSA key with correct RSA modulus" do
+        expect(key_attestation.key.n).to eq attested_key.n
+      end
+
+      it "returns a public RSA key with correct RSA exponent" do
+        expect(key_attestation.key.e).to eq attested_key.e
+      end
+    end
+
+    context "when RSA PSS algorithm" do
+      before do
+        unless OpenSSL::PKey::RSA.instance_methods.include?(:verify_pss)
+          skip "Ruby OpenSSL gem #{OpenSSL::VERSION} do not support RSASSA-PSS"
+        end
+      end
+
+      let(:signature_algorithm) { TPM::ALG_RSAPSS }
+      let(:signature) do
+        attestation_key.sign_pss(hash_function, to_be_signed, salt_length: :max, mgf1_hash: hash_function)
+      end
+
+      it "returns a public RSA key with correct size" do
+        expect(key_attestation.key.n.num_bits).to be 1024
+      end
+
+      it "returns a public RSA key with correct RSA modulus" do
+        expect(key_attestation.key.n).to eq attested_key.n
+      end
+
+      it "returns a public RSA key with correct RSA exponent" do
+        expect(key_attestation.key.e).to eq attested_key.e
+      end
+    end
+
+    context "when is not valid" do
+      before do
+        expect(key_attestation).to receive(:valid?).and_return(false)
+      end
+
+      it 'returns nil' do
+        expect(key_attestation.key).to be nil
       end
     end
   end


### PR DESCRIPTION
## What

There's is bug when using `libopenssl v1.0.2` where KeyAttestation#Key blows up with:

![Screen Shot 2020-05-20 at 3 48 56 PM](https://user-images.githubusercontent.com/46354312/82485197-728db580-9ab1-11ea-88c3-66b7bdeffbd5.png)

## Why

The error is produced in [this line](https://github.com/cedarcode/tpm-key_attestation/blob/a49e63a8b98c9c18242c3bec6c787459617d8f22/lib/tpm/t_public.rb#L77), after calling `OpenSSL::PKey::RSA#set_key`.

If we turn on the debug mode for OpenSSL – `OpenSSL.debug = true`, we get:

![Screen Shot 2020-05-20 at 3 33 16 PM](https://user-images.githubusercontent.com/46354312/82483810-67d22100-9aaf-11ea-9045-08731c205b34.png)

It seems that the error is caused because the we are not setting the field `e`, which is the exponent.

If we take a look into the [OpenSSL man page for the method RSA_set0_key](https://www.openssl.org/docs/man1.1.0/man3/RSA_set0_key.html), we can see that it states:

> The n, e and d parameter values can be set by calling RSA_set0_key() and passing the new values for n, e and d as parameters to the function. The values n and e must be non-NULL the first time this function is called on a given RSA object.

I still didn't figure out why it is failing only when using `OpenSSL v1.0.2` – and not when using `v1.1.1`.

## How

Given that we only support the default exponent as for now, we can just pass it to the method and it will work.

### How come that we only support the default exponent?

As specified in [TPMv2-Part2](https://www.trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-2-Structures-01.38.pdf) section `12.2.3.5`.

> A TPM compatible with this specification and supporting RSA shall support two primes and an exponent of zero. Support for other values is optional. Use of other exponents in duplicated keys is not recommended because the resulting keys would not be interoperable with other TPMs.
>
> NOTE: Implementations are not required to check that exponent is the default exponent. They may fail to load the key if exponent is not zero.

## Steps taken

- [x] - Write tests for reproducing bugs
- [x] - Configure Travis for testing against openssl v1.0.2 and v1.1.1
- [x] - Fix bug

## TBD

- [ ] - Find a way reduce the time that it takes to run each job, as it's taking aprox. 4 minutes each.
- [x] - Find a way of allowing jobs that use `ruby-head` to fail 