### PR TITLE
fix: TPM::KeyAttestation#valid? blowing up when using default root certificates and libopenssl v1.0.2

### DIFF
--- a/lib/tpm/key_attestation.rb
+++ b/lib/tpm/key_attestation.rb
@@ -86,7 +86,7 @@ module TPM
     def trust_store
       @trust_store ||=
         OpenSSL::X509::Store.new.tap do |trust_store|
-          root_certificates.each { |root_certificate| trust_store.add_cert(root_certificate) }
+          root_certificates.uniq(&:serial).each { |root_certificate| trust_store.add_cert(root_certificate) }
         end
     end
 

--- a/spec/tpm/key_attestation_spec.rb
+++ b/spec/tpm/key_attestation_spec.rb
@@ -78,6 +78,22 @@ RSpec.describe TPM::KeyAttestation do
       end
     end
 
+    context "when using the default root certificates" do
+      let(:root_certificates) { TPM::KeyAttestation::ROOT_CERTIFICATES }
+
+      let(:root_certificate) do
+        root_certificate = TPM::KeyAttestation::ROOT_CERTIFICATES.last
+        root_certificate.public_key = root_key
+        root_certificate.sign(root_key, OpenSSL::Digest::SHA256.new)
+
+        root_certificate
+      end
+
+      it "returns true" do
+        expect(key_attestation).to be_valid
+      end
+    end
+
     context "when RSA PSS algorithm" do
       before do
         unless OpenSSL::PKey::RSA.instance_methods.include?(:verify_pss)


### PR DESCRIPTION
## What

We found out that the method `trust_store` in `TPM::KeyAttestation` was blowing up when using the default root certificates and `libopenssl v1.0.2`, but we weren't getting that reflected in our CI.

## Why

The method [`add_cert`](https://rubyapi.org/2.7/o/OpenSSL/X509/Store.html#method-i-add_cert) from `OpenSSL:X509:Store` raises an exception if you try to add a cert that it's already present.
The problem is that there are duplicate certificates in `KeyAttestation::ROOT_CERTIFICATES`, particularly these two: [Microsoft RootCA](https://github.com/cedarcode/tpm-key_attestation/tree/d282d95df90ae77110eaf0fb64a7209a81f36938/lib/tpm/certificates/Microsoft/RootCA) and [QC RootCA](https://github.com/cedarcode/tpm-key_attestation/tree/d282d95df90ae77110eaf0fb64a7209a81f36938/lib/tpm/certificates/QC/RootCA).

## How

As the default certificates were extracted from [this page](https://docs.microsoft.com/en-us/windows-server/security/guarded-fabric-shielded-vm/guarded-fabric-install-trusted-tpm-root-certificates), we would like to avoid deleting the duplicates. Besides, we consider is better to refactor our code to avoid throwing an exception when adding a duplicate certificate so that the next time we update them we will not have to manually check for duplicates.

So, to fix this, we have to remove the duplicate certificates (certificates with same serial number) before adding them.