### PR TITLE
fix: race condition caused by the attribute `not_after` in a certificate being too short

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ def create_certificate(key, root_certificate, root_key)
   certificate.subject = OpenSSL::X509::Name.parse("")
   certificate.issuer = root_certificate.subject
   certificate.not_before = Time.now
-  certificate.not_after = Time.now + 60
+  certificate.not_after = Time.now + 120
   certificate.public_key = key
 
   certificate_basic_constraints = "CA:FALSE"


### PR DESCRIPTION
## What

There seems to be a race condition between the` not_after` attribute in `OpenSSL::X509::Certificate` and the execution that is causing the tests to be flaky.

## Why

As I mentioned [in the original discussion](https://github.com/cedarcode/tpm-key_attestation/pull/5#issuecomment-635422259), the problem is that when we create a certificate, we make it that is only valid for just 60 seconds. Therefore, if the execution takes longer than 60 seconds for checking if the certificate is valid, eventually the certificate will be considered invalid.

#### Backtrace

- [KeyAttestation#valid?](https://github.com/cedarcode/tpm-key_attestation/blob/868c6c0ed566de88cac61043dbdb5b4cb374ef92/lib/tpm/key_attestation.rb#L60:L64) fails because `aik_certificate.conformant?` returns `false`
- [AIKCertificate#conformant?](https://github.com/cedarcode/tpm-key_attestation/blob/868c6c0ed566de88cac61043dbdb5b4cb374ef92/lib/tpm/aik_certificate.rb#L23:L30) fails in `in_use?`
- [AIKCertificate#in_use?](https://github.com/cedarcode/tpm-key_attestation/blob/868c6c0ed566de88cac61043dbdb5b4cb374ef92/lib/tpm/aik_certificate.rb#L34:L38) fails given than `now < not_after` returns `false`

## How

To fix this, I decided to double the time in which a certificate is considered valid.