### PR TITLE
test: fix tests randomly failing due to certificates being 'not yet valid'

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ def create_certificate(key, root_certificate, root_key)
   certificate.version = 2
   certificate.subject = OpenSSL::X509::Name.parse("")
   certificate.issuer = root_certificate.subject
-  certificate.not_before = Time.now
+  certificate.not_before = Time.now - 1
   certificate.not_after = Time.now + 60
   certificate.public_key = key
 
@@ -82,7 +82,7 @@ def create_root_certificate(key)
   certificate.subject = OpenSSL::X509::Name.new([["CN", common_name]])
   certificate.issuer = certificate.subject
   certificate.public_key = key
-  certificate.not_before = Time.now
+  certificate.not_before = Time.now - 1
   certificate.not_after = Time.now + 60
 
   extension_factory = OpenSSL::X509::ExtensionFactory.new

--- a/spec/tpm/aik_certificate_spec.rb
+++ b/spec/tpm/aik_certificate_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "TPM::AIKCertificate" do
 
     let(:certificate_version) { 2 }
     let(:certificate_subject) { "" }
-    let(:certificate_start_time) { Time.now }
+    let(:certificate_start_time) { Time.now - 1 }
     let(:certificate_end_time) { certificate_start_time + 60 }
     let(:certificate_basic_constraints) { "CA:FALSE" }
     let(:certificate_extended_key_usage) { "2.23.133.8.3" }


### PR DESCRIPTION
## What

Test are being flaky in Travis, randomly failing returning that the certificate is not yet valid.

## Why

It seems that when checking if the certificate is valid, comparing `Time.now` with the attribute `not_before` of a certificate (that is also initiated with `Time.now`) is sometimes returning an error due to the difference being too short – it could be related with the comparison of floats that are close to each other.

#### Backtrace

- [KeyAttestation#valid?](https://github.com/cedarcode/tpm-key_attestation/blob/868c6c0ed566de88cac61043dbdb5b4cb374ef92/lib/tpm/key_attestation.rb#L60:L64) returns `false` because of `trustworthy?`.
- [KeyAttestation#trustworthy?](https://github.com/cedarcode/tpm-key_attestation/blob/58daeed47dbca03404f560f2aa34bf6fefc360df/lib/tpm/key_attestation.rb#L80:L84) return `false` given that `verify` returns `false`.

## How

To fix this, we just moved the `not_before` a little back in time, in order to make the difference larger when checking if it's valid.