### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.1'
           - '3.0'
           - '2.7'
           - '2.6'
@@ -25,6 +26,9 @@ jobs:
           - openssl_2_2
           - openssl_2_1
           - openssl_2_0
+        exclude:
+          - ruby: '3.1'
+            gemfile: openssl_2_0
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:


### PR DESCRIPTION
Adds Ruby 3.1 to the CI matrix.  Excludes the unsupported Ruby 3.1 / OpenSSL 2.0 combination.