### PR TITLE
Add Ruby 3.1 and 3.2 to the CI matrix.  Update checkout action version.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.2'
+          - '3.1'
           - '3.0'
           - '2.7'
           - '2.6'
@@ -33,7 +35,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: rm Gemfile.lock
     - uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Runs green on my fork.