### PR TITLE
Fix loading files on Windows by using File.binread instead of open

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,14 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-20.04
+          - windows-latest
+          - macos-latest
         ruby:
           - '3.2'
           - '3.1'

--- a/lib/tpm/key_attestation.rb
+++ b/lib/tpm/key_attestation.rb
@@ -15,7 +15,7 @@ module TPM
       begin
         pattern = File.expand_path(File.join(__dir__, "certificates", "*", "RootCA", "*.*"))
         Dir.glob(pattern).map do |filename|
-          File.open(filename) { |file| OpenSSL::X509::Certificate.new(file) }
+          File.binread(filename) { |file| OpenSSL::X509::Certificate.new(file) }
         end
       end
 


### PR DESCRIPTION
File.open does not work across all operating systems (particularly Windows) for binary files like DER format. File.binread is preferred here.

See: https://stackoverflow.com/a/30081354

This PR also adds tests across operating systems