### PR TITLE
Bugfix: Fixed value of TRUSTED_CERTIFICATES to be X509::Certificate object

### DIFF
--- a/lib/tpm/key_attestation.rb
+++ b/lib/tpm/key_attestation.rb
@@ -15,7 +15,8 @@ module TPM
       begin
         pattern = File.expand_path(File.join(__dir__, "certificates", "*", "RootCA", "*.*"))
         Dir.glob(pattern).map do |filename|
-          File.binread(filename) { |file| OpenSSL::X509::Certificate.new(file) }
+          file = File.binread(filename)
+          OpenSSL::X509::Certificate.new(file)
         end
       end
 


### PR DESCRIPTION
https://github.com/cedarcode/tpm-key_attestation/pull/20 introduced a bug in loading of trusted certificates.

It changed `File.open` with `File.binread`.
```diff
-          File.open(filename) { |file| OpenSSL::X509::Certificate.new(file) }
+          File.binread(filename) { |file| OpenSSL::X509::Certificate.new(file) }
```
When passing a block to `File.open`, the return value is of the block ([ref](https://ruby-doc.org/core-2.5.1/File.html#method-c-open)). But that's not the case with `File.binread`, it always return the content of file as read from disk ([ref](https://ruby-doc.org/core-2.5.1/IO.html#method-c-binread)).

To fix the issue, I separated the reading of file and initializing the `OpenSSL::X509::Certificate` into separate lines. This should ensure that the parent block of `map` always gets `OpenSSL::X509::Certificate` object for each file found.