### PR TITLE
Exclude failing MacOS and Windows jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,36 @@ jobs:
             gemfile: openssl_3_1
           - ruby: '2.5'
             gemfile: openssl_3_1
+          - ruby: '3.1'
+            gemfile: openssl_2_2
+            os: macos-latest
+          - ruby: '3.1'
+            gemfile: openssl_2_1
+            os: macos-latest
+          - ruby: '3.2'
+            gemfile: openssl_2_2
+            os: macos-latest
+          - ruby: '3.2'
+            gemfile: openssl_2_1
+            os: macos-latest
+          - ruby: '3.2'
+            gemfile: openssl_3_0
+            os: macos-latest
+          - ruby: '3.2'
+            gemfile: openssl_3_1
+            os: macos-latest
+          - ruby: '3.2'
+            gemfile: openssl_2_2
+            os: windows-latest
+          - ruby: '3.2'
+            gemfile: openssl_2_1
+            os: windows-latest
+          - ruby: '3.2'
+            gemfile: openssl_3_0
+            os: windows-latest
+          - ruby: '3.2'
+            gemfile: openssl_3_1
+            os: windows-latest
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:


### PR DESCRIPTION
This PR excludes failing MacOS and Windows jobs from running in the CI, as they are failing. This is a temporary solution, as my intention is to create issues to fix the problem.

Overall, the jobs are failing because of two reasons:

- In windows and macos, when using versions `3.1` and `3.2` of Ruby, `bundle install` fails to install versions of the `openssl` gem older than `3.0`.
- In windows and macos, when using version `3.2` of Ruby and versions `3.0` and `3.1` of `openssl`, there's a spec that's failing.