### PR TITLE
Fix tests failing with OpenSSL 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,22 +54,10 @@ jobs:
             gemfile: openssl_2_1
             os: macos-latest
           - ruby: '3.2'
-            gemfile: openssl_3_0
-            os: macos-latest
-          - ruby: '3.2'
-            gemfile: openssl_3_1
-            os: macos-latest
-          - ruby: '3.2'
             gemfile: openssl_2_2
             os: windows-latest
           - ruby: '3.2'
             gemfile: openssl_2_1
-            os: windows-latest
-          - ruby: '3.2'
-            gemfile: openssl_3_0
-            os: windows-latest
-          - ruby: '3.2'
-            gemfile: openssl_3_1
             os: windows-latest
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/spec/tpm/aik_certificate_spec.rb
+++ b/spec/tpm/aik_certificate_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "TPM::AIKCertificate" do
   context "#conformant?" do
     let(:certificate) do
       certificate = OpenSSL::X509::Certificate.new
-      certificate.version = certificate_version
+      certificate.version = 2
       certificate.subject = OpenSSL::X509::Name.parse(certificate_subject)
       certificate.not_before = certificate_start_time
       certificate.not_after = certificate_end_time
@@ -31,7 +31,6 @@ RSpec.describe "TPM::AIKCertificate" do
 
     let(:key) { create_rsa_key }
 
-    let(:certificate_version) { 2 }
     let(:certificate_subject) { "" }
     let(:certificate_start_time) { Time.now - 1 }
     let(:certificate_end_time) { certificate_start_time + 60 }
@@ -76,7 +75,9 @@ RSpec.describe "TPM::AIKCertificate" do
     end
 
     context "when version is incorrect" do
-      let(:certificate_version) { 3 }
+      before do
+        certificate.version = 3
+      end
 
       it "returns false" do
         expect(aik_certificate).not_to be_conformant


### PR DESCRIPTION
## Summary

Some tests [were failing in the CI](https://github.com/cedarcode/tpm-key_attestation/actions/runs/7671623115) when using `macos` because it comes with ruby installed with OpenSSL v3.2.0. The issue is that, for testing the `conformant?` method, we set up a certificate to have an invalid version (version is `3` initially) and expect the certificate to not be conformant. But when setting up the certificate we have to sign it which, in newer versions of OpenSSL, updates the version to a valid one (version changes to be `2`), thus causing the expectation to not be met and therefore the spec to fail.

This PR fixes the issue by changing the `version` _after_ the certificate has been signed.