### PR TITLE
Use `macos-12` image for running CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         os:
           - ubuntu-20.04
           - windows-latest
-          - macos-latest
+          - macos-12
         ruby:
           - '3.2'
           - '3.1'
@@ -47,16 +47,16 @@ jobs:
             gemfile: openssl_3_1
           - ruby: '3.1'
             gemfile: openssl_2_2
-            os: macos-latest
+            os: macos-12
           - ruby: '3.1'
             gemfile: openssl_2_1
-            os: macos-latest
+            os: macos-12
           - ruby: '3.2'
             gemfile: openssl_2_2
-            os: macos-latest
+            os: macos-12
           - ruby: '3.2'
             gemfile: openssl_2_1
-            os: macos-latest
+            os: macos-12
           - ruby: '3.2'
             gemfile: openssl_2_2
             os: windows-latest


### PR DESCRIPTION
`macos-latest` is now `macos-14` which doesn't support Ruby < 2.6:

```
Error: Error: CRuby < 2.6 does not support macos-arm64.
        Either use a newer Ruby version or use a macOS image running on amd64, e.g., macos-13 or macos-12.
        Note that GitHub changed the meaning of macos-latest from macos-12 (amd64) to macos-14 (arm64):
        https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/
```