### PR TITLE
Use public key from AIK cert for signature algorithm initalization

### DIFF
--- a/spec/tpm/key_attestation_spec.rb
+++ b/spec/tpm/key_attestation_spec.rb
@@ -215,6 +215,27 @@ RSpec.describe TPM::KeyAttestation do
           expect(key_attestation.key.public_key).to eq(attested_key.public_key)
         end
       end
+
+      context "when the key of the AIK certificate is an RSA key" do
+        let(:root_key) { create_rsa_key }
+        let(:cert_key) { create_rsa_key }
+
+        let(:certificate) do
+          create_certificate(cert_key, root_certificate, root_key)
+        end
+
+        let(:signature_algorithm) { TPM::ALG_RSASSA }
+        let(:hash_algorithm) { TPM::ALG_SHA256 }
+        let(:signature) { cert_key.sign(hash_function, to_be_signed) }
+
+        it "returns true" do
+          expect(key_attestation).to be_valid
+
+          expect(key_attestation.key).to be_a(OpenSSL::PKey::EC)
+          expect(key_attestation.key.group.curve_name).to eq("prime256v1")
+          expect(key_attestation.key.public_key).to eq(attested_key.public_key)
+        end
+      end
     end
 
     context "when signature is invalid" do


### PR DESCRIPTION
## Details

Attempts to fix #28.

Validation of the TPM attestation for Windows Hello with TPM v2 is failing as the AIK certificate public key was an RSA key and the public key `pubArea` was an ECC key – which causes the gem to try to initialize an `OpenSSL::SignatureAlgorithm::RSA` object with an `curve` keyword argument resulting in a `unknown keyword` error.

The problem is that we are using the key in the `pubArea` to verify the signature over `certInfo` whereas [the WebAuthn spec states that](https://www.w3.org/TR/2023/WD-webauthn-3-20230927/#sctn-tpm-cert-requirements:~:text=Verify%20the%20sig%20is%20a%20valid%20signature%20over%20certInfo%20using%20the%20attestation%20public%20key%20in%20aikCert%20with%20the%20algorithm%20specified%20in%20alg.):

> Verify the sig is a valid signature over certInfo using the attestation public key in aikCert with the algorithm specified in alg.