### PR TITLE
Fix `TPM::Attestation#key` raising invalid encoding errors when using `ECC` algorithm

### DIFF
--- a/lib/tpm/t_public.rb
+++ b/lib/tpm/t_public.rb
@@ -4,6 +4,7 @@ require "bindata"
 require "openssl"
 require "tpm/constants"
 require "tpm/sized_buffer"
+require "tpm/tpms_ecc_point"
 require "tpm/t_public/s_ecc_parms"
 require "tpm/t_public/s_rsa_parms"
 
@@ -42,7 +43,7 @@ module TPM
     end
 
     choice :unique, selection: :alg_type do
-      sized_buffer TPM::ALG_ECC
+      tpms_ecc_point TPM::ALG_ECC
       sized_buffer TPM::ALG_RSA
     end
 
@@ -77,7 +78,10 @@ module TPM
     def ecc_key
       if parameters.scheme == TPM::ALG_ECDSA
         group = OpenSSL::PKey::EC::Group.new(openssl_curve_name)
-        point = OpenSSL::PKey::EC::Point.new(group, bn(ECC_UNCOMPRESSED_POINT_INDICATOR + unique.buffer.value))
+        point = OpenSSL::PKey::EC::Point.new(
+          group,
+          bn(ECC_UNCOMPRESSED_POINT_INDICATOR + unique.x.buffer.value + unique.y.buffer.value)
+        )
 
         # RFC5480 SubjectPublicKeyInfo
         asn1 = OpenSSL::ASN1::Sequence(

--- a/lib/tpm/tpms_ecc_point.rb
+++ b/lib/tpm/tpms_ecc_point.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "bindata"
+
+module TPM
+  class TpmsEccPoint < BinData::Record
+    endian :big
+
+    sized_buffer :x
+    sized_buffer :y
+  end
+end

--- a/spec/tpm/key_attestation_spec.rb
+++ b/spec/tpm/key_attestation_spec.rb
@@ -173,7 +173,11 @@ RSpec.describe TPM::KeyAttestation do
         t_public.parameters.scheme = TPM::ALG_ECDSA
         t_public.parameters.curve_id = curve_id
         t_public.parameters.kdf = TPM::ALG_NULL
-        t_public.unique.buffer = attested_key.public_key.to_bn.to_s(2)[1..-1]
+
+        public_key_bytes = attested_key.public_key.to_bn.to_s(2)[1..-1]
+        coordinate_length = public_key_bytes.size / 2
+        t_public.unique.x.buffer = public_key_bytes[0..(coordinate_length - 1)]
+        t_public.unique.y.buffer = public_key_bytes[coordinate_length..-1]
 
         t_public.to_binary_s
       end


### PR DESCRIPTION
Attempts to fix #31.