### PR TITLE
Bump GitHub Actions CI from `macos-12` to `macos-13`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         os:
           - ubuntu-20.04
           - windows-latest
-          - macos-12
+          - macos-13
         ruby:
           - '3.2'
           - '3.1'
@@ -47,16 +47,16 @@ jobs:
             gemfile: openssl_3_1
           - ruby: '3.1'
             gemfile: openssl_2_2
-            os: macos-12
+            os: macos-13
           - ruby: '3.1'
             gemfile: openssl_2_1
-            os: macos-12
+            os: macos-13
           - ruby: '3.2'
             gemfile: openssl_2_2
-            os: macos-12
+            os: macos-13
           - ruby: '3.2'
             gemfile: openssl_2_1
-            os: macos-12
+            os: macos-13
           - ruby: '3.2'
             gemfile: openssl_2_2
             os: windows-latest


### PR DESCRIPTION
It seems that `macos-12` has been deprecated:

```
The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721
```

which is making our `macOS` tests to be cancelled.

[The latest `macOS` environments don't support Ruby 2.6](https://github.com/cedarcode/tpm-key_attestation/commit/0faef490) so we are just upgrading to `macOS-13` for the moment. We might evaluate dropping support for older Ruby versions in the future...