### PR TITLE
Handle incompatibility between `parameters` and `unique` in `TPublic`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tpm-key_attestation (0.12.1)
+    tpm-key_attestation (0.13.1)
       bindata (~> 2.4)
       openssl (> 2.0)
       openssl-signature_algorithm (~> 1.0)

--- a/lib/tpm/t_public.rb
+++ b/lib/tpm/t_public.rb
@@ -99,6 +99,8 @@ module TPM
 
         OpenSSL::PKey::EC.new(asn1.to_der)
       end
+    rescue OpenSSL::PKey::EC::Point::Error
+      nil
     end
 
     def rsa_key


### PR DESCRIPTION
## Summary

This PR addresses an issue where the `t_public.parameters` and `t_public.unique` are incompatible by preventing the gem from raising an exception when this happens and just returning `nil` as result of `TPM:KeyAttestation#key`.

## Why?
We discovered this issue after upgrading `tpm-key_attestation` to `0.13.1` in [cedarcode/webauthn-ruby#449](https://github.com/cedarcode/webauthn-ruby/pull/449). During this upgrade, a [test failure](https://github.com/cedarcode/webauthn-ruby/blob/6fa48314a3c9743d3a2097808ca5e9249d60d84b/spec/webauthn/attestation_statement/tpm_spec.rb#L244-L256) in the `WebAuthn` test suite revealed an unsupported edge case: calling the `key` method of `KeyAttestation` raises an exception when `t_public.parameters` and `t_public.unique` are incompatible.

The exception occurs in the following code:

https://github.com/cedarcode/tpm-key_attestation/blob/8ea5976f8dda824e135e0129f708d865370a08b8/lib/tpm/t_public.rb#L82-L85

This issue went unnoticed before because `key_attestation.valid?` used to return `false` (because it failed to validate the signature), preventing `key_attestation.key` from being called. However, after changes to the signature validation process in https://github.com/cedarcode/tpm-key_attestation/pull/29, `valid?` now returns `true` for this scenario, which led the test to fail because the `pubArea` for this scenario was set up with incompatible `parameters` and `unique` attributes (because the coordinates `x` and `y` are inconsistent with its `curve`).


Although we haven’t encountered this scenario in real-world applications, the `WebAuthn` test suite helped uncover this validation gap.