### PR TITLE
Drop support for end-of-life `Ruby` versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,6 @@ jobs:
           - '3.3'
           - '3.2'
           - '3.1'
-          - '3.0'
-          - '2.7'
-          - '2.6'
-          - '2.5'
-          - '2.4'
         gemfile:
           - openssl_2_2
           - openssl_2_1
@@ -39,20 +34,6 @@ jobs:
           - openssl_3_1
           - openssl_3_2
         exclude:
-          - ruby: '2.4'
-            gemfile: openssl_3_0
-          - ruby: '2.5'
-            gemfile: openssl_3_0
-          - ruby: '2.4'
-            gemfile: openssl_3_1
-          - ruby: '2.5'
-            gemfile: openssl_3_1
-          - ruby: '2.4'
-            gemfile: openssl_3_2
-          - ruby: '2.5'
-            gemfile: openssl_3_2
-          - ruby: '2.6'
-            gemfile: openssl_3_2
           - ruby: '3.1'
             gemfile: openssl_2_2
             os: macos-13

--- a/tpm-key_attestation.gemspec
+++ b/tpm-key_attestation.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "TPM Key Attestation verifier"
   spec.homepage      = "https://github.com/cedarcode/tpm-key_attestation"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
## Summary

This PR officially drops support for `Ruby` versions that have [reached their end of life](https://endoflife.date/ruby).

The `TargetRubyVersion` parameter in `.rubocop.yml` will be updated when we upgrade to the latest version of `RuboCop` in #40, as the current version does not support `Ruby 3.1`.

