### PR TITLE
Manually install OpenSSL `1.1.1w` in `ubuntu` in the CI

### DIFF
--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -1,0 +1,36 @@
+name: Install OpenSSL
+inputs:
+  version:
+    description: 'The version of OpenSSL to install'
+    required: true
+  os:
+    description: 'The operating system to install OpenSSL on'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache OpenSSL library
+      id: cache-openssl
+      uses: actions/cache@v4
+      with:
+        path: ~/openssl
+        key: openssl-${{ inputs.version }}-${{ inputs.os }}
+
+    - name: Compile OpenSSL library
+      if: steps.cache-openssl.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p tmp/build-openssl && cd tmp/build-openssl
+        case ${{ inputs.version }} in
+        1.1.*)
+          OPENSSL_COMMIT=OpenSSL_
+          OPENSSL_COMMIT+=$(echo ${{ inputs.version  }} | sed -e 's/\./_/g')
+          git clone -b $OPENSSL_COMMIT --depth 1 https://github.com/openssl/openssl.git .
+          echo "Git commit: $(git rev-parse HEAD)"
+          ./Configure --prefix=$HOME/openssl --libdir=lib linux-x86_64
+          make depend && make -j4 && make install_sw
+          ;;
+        *)
+          echo "Don't know how to build OpenSSL ${{ inputs.version }}"
+          ;;
+        esac

--- a/.github/actions/install-ruby/action.yml
+++ b/.github/actions/install-ruby/action.yml
@@ -37,10 +37,20 @@ runs:
       run: |
         echo "~/rubies/ruby-${{ inputs.version }}/bin" >> $GITHUB_PATH
 
-    - name: Install Bundler (if Ruby <= 2.6)
-      if: startsWith(inputs.version, '2.5') || startsWith(inputs.version, '2.6')
+    - name: Install Bundler
       shell: bash
-      run: gem install bundler -v '~> 2.3.0'
+      run: |
+        case ${{ inputs.version }} in
+        2.7* | 3.*)
+          echo "Skipping Bundler installation for Ruby ${{ inputs.version }}"
+          ;;
+        2.5* | 2.6*)
+          gem install bundler -v '~> 2.3.0'
+          ;;
+        *)
+          echo "Don't know how to install Bundler for Ruby ${{ inputs.version }}"
+          ;;
+        esac
 
     - name: Cache Bundler Install
       id: bundler-cache

--- a/.github/actions/install-ruby/action.yml
+++ b/.github/actions/install-ruby/action.yml
@@ -1,0 +1,58 @@
+name: Install Ruby
+inputs:
+  version:
+    description: 'The version of Ruby to install'
+    required: true
+  os:
+    description: 'The operating system to install Ruby on'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache Ruby
+      id: ruby-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/rubies/ruby-${{ inputs.version }}
+        key: ruby-${{ inputs.version }}-${{ inputs.os }}-openssl-1.1.1w
+
+    - name: Install Ruby
+      if: steps.ruby-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        latest_patch=$(curl -s https://cache.ruby-lang.org/pub/ruby/${{ inputs.version }}/ \
+           | grep -oP "ruby-${{ inputs.version }}\.\d+\.tar\.xz" \
+           | grep -oP "\d+(?=\.tar\.xz)" \
+           | sort -V | tail -n 1)
+
+        wget https://cache.ruby-lang.org/pub/ruby/${{ inputs.version }}/ruby-${{ inputs.version }}.${latest_patch}.tar.xz
+        tar -xJvf ruby-${{ inputs.version }}.${latest_patch}.tar.xz
+        cd ruby-${{ inputs.version }}.${latest_patch}
+        ./configure --prefix=$HOME/rubies/ruby-${{ inputs.version }} --with-openssl-dir=$HOME/openssl
+        make
+        make install
+
+    - name: Update PATH
+      shell: bash
+      run: |
+        echo "~/rubies/ruby-${{ inputs.version }}/bin" >> $GITHUB_PATH
+
+    - name: Install Bundler (if Ruby <= 2.6)
+      if: startsWith(inputs.version, '2.5') || startsWith(inputs.version, '2.6')
+      shell: bash
+      run: gem install bundler -v '~> 2.3.0'
+
+    - name: Cache Bundler Install
+      id: bundler-cache
+      uses: actions/cache@v4
+      env:
+        GEMFILE: ${{ env.BUNDLE_GEMFILE || 'Gemfile' }}
+      with:
+        path: ./vendor/bundle
+        key: bundler-ruby-${{ inputs.version }}-${{ inputs.os }}-${{ hashFiles(env.Gemfile, 'tpm-key_attestation.gemspec') }}
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        bundle config set --local path ../vendor/bundle
+        bundle install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,13 +118,33 @@ jobs:
           - ruby: '3.4'
             gemfile: openssl_2_1
             os: windows-latest
+          - ruby: '2.4'
+            os: ubuntu-20.04
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
     - uses: actions/checkout@v4
+
     - run: rm Gemfile.lock
+
+    - name: Install OpenSSL
+      if: matrix.os == 'ubuntu-20.04'
+      uses: ./.github/actions/install-openssl
+      with:
+        version: "1.1.1w"
+        os: ${{ matrix.os }}
+
     - uses: ruby/setup-ruby@v1
+      if: matrix.os != 'ubuntu-20.04'
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+
+    - name: Manually set up Ruby
+      if: matrix.os == 'ubuntu-20.04'
+      uses: ./.github/actions/install-ruby
+      with:
+        version: ${{ matrix.ruby }}
+        os: ${{ matrix.os }}
+
     - run: bundle exec rspec


### PR DESCRIPTION
## Motivation

We got a notification that `ubuntu-20` images are being deprecated:

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down

After upgrading to `ubuntu-22` or `ubuntu-24` a lot of tests started to break due to the Rubies on those images coming with OpenSSL version 3+. That means that, by upgrading, we wouldn't have any way of testing against OpenSSL 1.1.1w

We still want to test against OpenSSL `1.1.1w` despite it being EOL.

## Summary

This PR updates our CI to manually install OpenSSL and Ruby so that we test against different OpenSSL versions, without having to rely on the OpenSSL version that comes with the OS' ruby.

## Upcoming

This opens the door to add another variable to the matrix: OpenSSL version. We will open a follow up PR for that.