### PR TITLE
Update CI to run on `ubuntu-24`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
           - windows-latest
           - macos-13
         ruby:
@@ -119,7 +119,7 @@ jobs:
             gemfile: openssl_2_1
             os: windows-latest
           - ruby: '2.4'
-            os: ubuntu-20.04
+            os: ubuntu-24.04
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
@@ -128,20 +128,20 @@ jobs:
     - run: rm Gemfile.lock
 
     - name: Install OpenSSL
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-24.04'
       uses: ./.github/actions/install-openssl
       with:
         version: "1.1.1w"
         os: ${{ matrix.os }}
 
     - uses: ruby/setup-ruby@v1
-      if: matrix.os != 'ubuntu-20.04'
+      if: matrix.os != 'ubuntu-24.04'
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
 
     - name: Manually set up Ruby
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-24.04'
       uses: ./.github/actions/install-ruby
       with:
         version: ${{ matrix.ruby }}


### PR DESCRIPTION
## Summary

This `PR` updates the `CI` ro run on `ubuntu-24` which is the latest `ubuntu` image available.

## Why?

`ubuntu-20` image was deprecated.

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down