### PR TITLE
Expect different `OID` value when using `OpenSSL >= 3.5.0`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
           - windows-latest
           - macos-13
         ruby:
@@ -115,7 +115,7 @@ jobs:
             gemfile: openssl_2_1
             os: windows-latest
           - ruby: '2.4'
-            os: ubuntu-20.04
+            os: ubuntu-24.04
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
@@ -124,20 +124,20 @@ jobs:
     - run: rm Gemfile.lock
 
     - name: Install OpenSSL
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-24.04'
       uses: ./.github/actions/install-openssl
       with:
         version: "1.1.1w"
         os: ${{ matrix.os }}
 
     - uses: ruby/setup-ruby@v1
-      if: matrix.os != 'ubuntu-20.04'
+      if: matrix.os != 'ubuntu-24.04'
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
 
     - name: Manually set up Ruby
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-24.04'
       uses: ./.github/actions/install-ruby
       with:
         version: ${{ matrix.ruby }}

--- a/lib/tpm/aik_certificate.rb
+++ b/lib/tpm/aik_certificate.rb
@@ -7,14 +7,15 @@ require "tpm/constants"
 module TPM
   # Section 3.2 in https://www.trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf
   class AIKCertificate < SimpleDelegator
+    OPENSSL_VERSION = OpenSSL::OPENSSL_LIBRARY_VERSION.match(/\d+\.\d+\.\d+/).to_s
     ASN_V3 = 2
     EMPTY_NAME = OpenSSL::X509::Name.new([]).freeze
     SAN_DIRECTORY_NAME = 4
     OID_TCG = "2.23.133"
-    OID_TCG_AT_TPM_MANUFACTURER = "#{OID_TCG}.2.1"
-    OID_TCG_AT_TPM_MODEL = "#{OID_TCG}.2.2"
-    OID_TCG_AT_TPM_VERSION = "#{OID_TCG}.2.3"
-    OID_TCG_KP_AIK_CERTIFICATE = "#{OID_TCG}.8.3"
+    OID_TCG_AT_TPM_MANUFACTURER = OPENSSL_VERSION >= "3.5.0" ? "tcg-at-tpmManufacturer" : "#{OID_TCG}.2.1"
+    OID_TCG_AT_TPM_MODEL = OPENSSL_VERSION >= "3.5.0" ? "tcg-at-tpmModel" : "#{OID_TCG}.2.2"
+    OID_TCG_AT_TPM_VERSION = OPENSSL_VERSION >= "3.5.0" ? "tcg-at-tpmVersion" : "#{OID_TCG}.2.3"
+    OID_TCG_KP_AIK_CERTIFICATE = OPENSSL_VERSION >= "3.5.0" ? "Attestation Identity Key Certificate" : "#{OID_TCG}.8.3"
 
     def self.from_der(certificate_der)
       new(OpenSSL::X509::Certificate.new(certificate_der))

--- a/lib/tpm/aik_certificate.rb
+++ b/lib/tpm/aik_certificate.rb
@@ -3,19 +3,27 @@
 require "delegate"
 require "openssl"
 require "tpm/constants"
+require "tpm/openssl_helper"
 
 module TPM
   # Section 3.2 in https://www.trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf
   class AIKCertificate < SimpleDelegator
-    OPENSSL_VERSION = OpenSSL::OPENSSL_LIBRARY_VERSION.match(/\d+\.\d+\.\d+/).to_s
     ASN_V3 = 2
     EMPTY_NAME = OpenSSL::X509::Name.new([]).freeze
     SAN_DIRECTORY_NAME = 4
-    OID_TCG = "2.23.133"
-    OID_TCG_AT_TPM_MANUFACTURER = OPENSSL_VERSION >= "3.5.0" ? "tcg-at-tpmManufacturer" : "#{OID_TCG}.2.1"
-    OID_TCG_AT_TPM_MODEL = OPENSSL_VERSION >= "3.5.0" ? "tcg-at-tpmModel" : "#{OID_TCG}.2.2"
-    OID_TCG_AT_TPM_VERSION = OPENSSL_VERSION >= "3.5.0" ? "tcg-at-tpmVersion" : "#{OID_TCG}.2.3"
-    OID_TCG_KP_AIK_CERTIFICATE = OPENSSL_VERSION >= "3.5.0" ? "Attestation Identity Key Certificate" : "#{OID_TCG}.8.3"
+
+    if TPM::OpenSSLHelper.running_openssl_version_35_or_up?
+      OID_TCG_AT_TPM_MANUFACTURER = "tcg-at-tpmManufacturer"
+      OID_TCG_AT_TPM_MODEL = "tcg-at-tpmModel"
+      OID_TCG_AT_TPM_VERSION = "tcg-at-tpmVersion"
+      OID_TCG_KP_AIK_CERTIFICATE = "Attestation Identity Key Certificate"
+    else
+      OID_TCG = "2.23.133"
+      OID_TCG_AT_TPM_MANUFACTURER = "#{OID_TCG}.2.1"
+      OID_TCG_AT_TPM_MODEL = "#{OID_TCG}.2.2"
+      OID_TCG_AT_TPM_VERSION = "#{OID_TCG}.2.3"
+      OID_TCG_KP_AIK_CERTIFICATE = "#{OID_TCG}.8.3"
+    end
 
     def self.from_der(certificate_der)
       new(OpenSSL::X509::Certificate.new(certificate_der))

--- a/lib/tpm/openssl_helper.rb
+++ b/lib/tpm/openssl_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module TPM
+  module OpenSSLHelper
+    def self.running_openssl_version_35_or_up?
+      OpenSSL::OPENSSL_LIBRARY_VERSION.match(/\d+\.\d+\.\d+/).to_s >= "3.5.0"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

After upgrading to `OpenSSL` `3.5.0` we noticed that the value returned from the `OpenSSL::X509::ExtensionFactory` is not the `oid` but a descriptive name, to handle both scenarios we define the expected value based on the OpenSSL library version that is being used.

Also this PR updates the ubuntu image to `ubuntu-24` since `ubuntu-20` had been removed from `Github Actions`.




Closes #51 