### PR TITLE
Ignore job when using Ruby 3.4, openssl 3.0 and windows-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,9 @@ jobs:
           - ruby: '3.4'
             gemfile: openssl_2_1
             os: windows-latest
+          - ruby: '3.4'
+            gemfile: openssl_3_0
+            os: windows-latest
           - ruby: '2.4'
             os: ubuntu-24.04
     env:


### PR DESCRIPTION
## Summary
The CI is currently failing on Windows-latest, Ruby 3.4.4 and OpenSSL 3.0.3 (gem) when installing the OpenSSL gem with the following compiler error:

```sh
compiling ossl_asn1.c
ossl_asn1.c: In function 'ossl_asn1_get_asn1type':
ossl_asn1.c:525:19: error: assignment to 'void (*)(void)' from incompatible
pointer type 'void (*)(ASN1_INTEGER *)' {aka 'void (*)(struct asn1_string_st
*)'} [-Wincompatible-pointer-types]
  525 |         free_func = ASN1_INTEGER_free;
      |                   ^
In file included from ossl.h:23,
                 from ossl_asn1.c:10:
D:/a/_temp/msys64/ucrt64/include/openssl/asn1.h:730:1: note: 'ASN1_INTEGER_free'
declared here
  730 | DECLARE_ASN1_FUNCTIONS(ASN1_INTEGER)
      | ^~~~~~~~~~~~~~~~~~~~~~
 ```
Upon inspecting the file where the error occurs ([ext/openssl/ossl_asn1.c](https://github.com/ruby/openssl/blob/master/ext/openssl/ossl_asn1.c) in the openssl gem), I found that a probably related warning was addressed between OpenSSL versions 3.0.3 and 3.1.0. Specifically, [this commit](https://github.com/ruby/openssl/commit/e25de6b280977281f90b6b2068198f20ce824665) in the OpenSSL repo seems to have resolved the incompatible pointer warning.

Since this problem does not occur in OpenSSL 3.1.0 and later-and OpenSSL 3.0.x is now in security maintenance mode only-it makes sense to exclude this job