### PR TITLE
Ignore failing `windows` and `openssl` `v3.0` jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,9 @@ jobs:
           - ruby: '3.2'
             gemfile: openssl_2_1
             os: windows-latest
+          - ruby: '3.2'
+            gemfile: openssl_3_0
+            os: windows-latest
           - ruby: '3.3'
             gemfile: openssl_2_2
             os: macos-13
@@ -101,6 +104,9 @@ jobs:
             os: windows-latest
           - ruby: '3.3'
             gemfile: openssl_2_1
+            os: windows-latest
+          - ruby: '3.3'
+            gemfile: openssl_3_0
             os: windows-latest
           - ruby: '3.4'
             gemfile: openssl_2_2


### PR DESCRIPTION
Sames as #54 but for Ruby 3.2 and 3.3.