### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         os:
           - ubuntu-24.04
           - windows-latest
-          - macos-13
+          - macos-15
         ruby:
           - '3.4'
           - '3.3'
@@ -74,16 +74,16 @@ jobs:
             gemfile: openssl_3_3
           - ruby: '3.1'
             gemfile: openssl_2_2
-            os: macos-13
+            os: macos-15
           - ruby: '3.1'
             gemfile: openssl_2_1
-            os: macos-13
+            os: macos-15
           - ruby: '3.2'
             gemfile: openssl_2_2
-            os: macos-13
+            os: macos-15
           - ruby: '3.2'
             gemfile: openssl_2_1
-            os: macos-13
+            os: macos-15
           - ruby: '3.2'
             gemfile: openssl_2_2
             os: windows-latest
@@ -92,10 +92,10 @@ jobs:
             os: windows-latest
           - ruby: '3.3'
             gemfile: openssl_2_2
-            os: macos-13
+            os: macos-15
           - ruby: '3.3'
             gemfile: openssl_2_1
-            os: macos-13
+            os: macos-15
           - ruby: '3.3'
             gemfile: openssl_2_2
             os: windows-latest
@@ -104,10 +104,10 @@ jobs:
             os: windows-latest
           - ruby: '3.4'
             gemfile: openssl_2_2
-            os: macos-13
+            os: macos-15
           - ruby: '3.4'
             gemfile: openssl_2_1
-            os: macos-13
+            os: macos-15
           - ruby: '3.4'
             gemfile: openssl_2_2
             os: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,10 @@ jobs:
           - openssl_3_3
         exclude:
           - ruby: '2.4'
+            os: macos-15
+          - ruby: '2.5'
+            os: macos-15
+          - ruby: '2.4'
             gemfile: openssl_3_0
           - ruby: '2.5'
             gemfile: openssl_3_0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,9 @@ jobs:
           - ruby: '3.2'
             gemfile: openssl_2_1
             os: windows-latest
+          - ruby: '3.2'
+            gemfile: openssl_3_0
+            os: windows-latest
           - ruby: '3.3'
             gemfile: openssl_2_2
             os: macos-15
@@ -105,6 +108,9 @@ jobs:
             os: windows-latest
           - ruby: '3.3'
             gemfile: openssl_2_1
+            os: windows-latest
+          - ruby: '3.3'
+            gemfile: openssl_3_0
             os: windows-latest
           - ruby: '3.4'
             gemfile: openssl_2_2


### PR DESCRIPTION
## Details

* Ignore failing `windows` and `openssl` v3.0 jobs – same as https://github.com/cedarcode/tpm-key_attestation/pull/54 but for Ruby 3.2 and 3.3.
* Run tests in `macos-15` instead of `macos-13` as the latter [is deprecated](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/).