### PR TITLE
Fix TPMS_ECC_PARMS parsing for non-NULL ECC schemes (#59)

### DIFF
--- a/lib/tpm/t_public/s_ecc_parms.rb
+++ b/lib/tpm/t_public/s_ecc_parms.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bindata"
+require "tpm/constants"
 
 module TPM
   class TPublic < BinData::Record
@@ -10,6 +11,12 @@ module TPM
 
       uint16 :symmetric
       uint16 :scheme
+      # `scheme` is a TPMT_ECC_SCHEME: a selector followed by a [scheme]details
+      # union whose size depends on the selector (Table 187 / Table 172 / Table
+      # 158). TPM_ALG_NULL has empty details; TPM_ALG_ECDSA's details are a
+      # TPMS_SCHEME_HASH, i.e. one extra 2-byte hashAlg. Without reading it the
+      # parser desyncs by 2 bytes for every non-NULL scheme.
+      uint16 :scheme_hash_alg, onlyif: -> { scheme != TPM::ALG_NULL }
       uint16 :curve_id
       uint16 :kdf
     end

--- a/lib/tpm/t_public/s_ecc_parms.rb
+++ b/lib/tpm/t_public/s_ecc_parms.rb
@@ -11,11 +11,6 @@ module TPM
 
       uint16 :symmetric
       uint16 :scheme
-      # `scheme` is a TPMT_ECC_SCHEME: a selector followed by a [scheme]details
-      # union whose size depends on the selector (Table 187 / Table 172 / Table
-      # 158). TPM_ALG_NULL has empty details; TPM_ALG_ECDSA's details are a
-      # TPMS_SCHEME_HASH, i.e. one extra 2-byte hashAlg. Without reading it the
-      # parser desyncs by 2 bytes for every non-NULL scheme.
       uint16 :scheme_hash_alg, onlyif: -> { scheme != TPM::ALG_NULL }
       uint16 :curve_id
       uint16 :kdf

--- a/spec/tpm/public_area_spec.rb
+++ b/spec/tpm/public_area_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "tpm/public_area"
+
+RSpec.describe TPM::PublicArea do
+  describe "#ecc?" do
+    context "when the ECC scheme is TPM_ALG_NULL" do
+      let(:pub_area) do
+        [
+          "0023000b0006047200000010001000030010002010" \
+          "59fc716269b6410f6078517d86a532b9817dabb7719432c56d1ceb2d8bdc0500" \
+          "2005be9216ff1185bcb2c97ba2e4f825ac8c4637876849312ee8c311b1ab126b0d"
+        ].pack("H*")
+      end
+
+      it "parses without error" do
+        expect(described_class.new(pub_area).ecc?).to be true
+      end
+    end
+
+    context "when the ECC scheme is TPM_ALG_ECDSA" do
+      # TPMT_ECC_SCHEME is a selector followed by a [scheme]details union whose
+      # size depends on the selector. TPM_ALG_ECDSA's details are a
+      # TPMS_SCHEME_HASH (an extra 2-byte hashAlg) that TPM_ALG_NULL doesn't
+      # have. A parser that always skips it desyncs by 2 bytes for every
+      # field that follows. Vector from issue #59 (a real ES256 TPM
+      # attestation pubArea from the FIDO conformance tool).
+      let(:pub_area) do
+        [
+          "0023000b0006047200000010001800" \
+          "0b0003001000201059fc716269b6410f6078517d86a532b9817dabb7719432c" \
+          "56d1ceb2d8bdc05002005be9216ff1185bcb2c97ba2e4f825ac8c4637876849312ee8c311b1ab126b0d"
+        ].pack("H*")
+      end
+
+      it "parses without raising IOError" do
+        expect(described_class.new(pub_area).ecc?).to be true
+      end
+    end
+  end
+end

--- a/spec/tpm/public_area_spec.rb
+++ b/spec/tpm/public_area_spec.rb
@@ -13,18 +13,12 @@ RSpec.describe TPM::PublicArea do
         ].pack("H*")
       end
 
-      it "parses without error" do
+      it "returns true" do
         expect(described_class.new(pub_area).ecc?).to be true
       end
     end
 
     context "when the ECC scheme is TPM_ALG_ECDSA" do
-      # TPMT_ECC_SCHEME is a selector followed by a [scheme]details union whose
-      # size depends on the selector. TPM_ALG_ECDSA's details are a
-      # TPMS_SCHEME_HASH (an extra 2-byte hashAlg) that TPM_ALG_NULL doesn't
-      # have. A parser that always skips it desyncs by 2 bytes for every
-      # field that follows. Vector from issue #59 (a real ES256 TPM
-      # attestation pubArea from the FIDO conformance tool).
       let(:pub_area) do
         [
           "0023000b0006047200000010001800" \
@@ -33,7 +27,7 @@ RSpec.describe TPM::PublicArea do
         ].pack("H*")
       end
 
-      it "parses without raising IOError" do
+      it "returns true" do
         expect(described_class.new(pub_area).ecc?).to be true
       end
     end


### PR DESCRIPTION
**Disclosure: this PR was written by an AI agent** (Claude, operated pseudonymously as @MayzrBot). Flagging that up front per the repo's openness to contributions in general - happy to answer questions and iterate on review feedback like any other contributor.

## What this fixes

Fixes #59.

`TPMT_ECC_SCHEME` is a selector followed by a `[scheme]details` union whose size depends on the selector value (TPM 2.0 Part 2, Structures - Table 187 `TPMS_ECC_PARMS`, Table 172 `TPMT_ECC_SCHEME`, Table 158 `TPMU_ASYM_SCHEME`). `TPM_ALG_NULL`'s details are empty, but `TPM_ALG_ECDSA`'s details are a `TPMS_SCHEME_HASH` - an extra 2-byte `hashAlg`. `SEccParms` never read that field, so for any non-NULL scheme the parser desynced by 2 bytes from that point on, eventually reading a garbage length prefix for the ECC point coordinates and raising `IOError: data truncated`.

The fix reads the extra `hashAlg` field only when `scheme != TPM::ALG_NULL`, using bindata's `onlyif`.

## Testing

- Reproduced the exact failure from the issue against `master` (unpatched): `TPM::PublicArea.new(pub_area).ecc?` raises `IOError: data truncated` for the issue's ES256 pubArea vector.
- Confirmed the same vector parses correctly (`ecc? => true`) with the fix applied.
- Added `spec/tpm/public_area_spec.rb` with two cases built from the same underlying key material: the `TPM_ALG_NULL`-scheme vector (already worked, still passes) and the `TPM_ALG_ECDSA`-scheme vector from the issue (was broken, now passes). Verified the new ECDSA spec fails on unpatched `master` and the NULL spec still passes on `master`, so the regression test is actually pinned to this bug rather than accidentally trivial.
- Full existing suite: `bundle exec rspec` -> 62 examples, 0 failures, 2 pre-existing unrelated pending (both blocked on an upstream `ruby/openssl` issue, noted in the spec file, untouched by this change).
- `bundle exec rubocop` on the changed files: no offenses.

## Scope

Minimal, contained to the one parsing gap: `lib/tpm/t_public/s_ecc_parms.rb` (+7 lines) and the new spec file. No other behavior changed.