### PR TITLE
Add Github Action for releasing gem using Rubygems' Trusted Publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: Publish to Rubygems
+
+    runs-on: ubuntu-latest
+
+    environment: release
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Publish to RubyGems
+        uses: rubygems/release-gem@v1


### PR DESCRIPTION
This PR adds a `release` Github Action workflow for releasing the gem to RubyGems using [Trusted Publishers](https://guides.rubygems.org/trusted-publishing/). To achieve that, it simply uses [`rubygems/release-gem` GitHub Action](https://github.com/rubygems/release-gem).

The workflow is run in the `release` Github Environment so the maintainers can approve the workflow run.